### PR TITLE
switch compare operator depending on sort order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.4] - 2025-01-02
+
+- Fix comparison operators for DESC sort order
+
 ## [1.0.3] - 2024-07-26
 
 - Return the correct final set when given `before` and `last`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typeorm-relay-connection",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "TypeORM implementation of Relay Connection spec",
   "license": "GPL-3.0",
   "author": "Lance Ivy <lance@cainlevy.net>",

--- a/src/TypeORMRelayConnection.test.ts
+++ b/src/TypeORMRelayConnection.test.ts
@@ -221,4 +221,44 @@ describe("TypeORMRelayConnection", () => {
     expect((await slice.pageInfo()).hasPreviousPage).toBeTruthy();
     expect((await slice.pageInfo()).hasNextPage).toBeTruthy();
   });
+
+  test("after when sortingKey is not id and sortingOrder is DESC", async () => {
+    const slice = new TypeORMRelayConnection(
+      qb,
+      {
+        after: "5",
+        first: 4,
+      },
+      {
+        sortingOrder: "DESC",
+        sortingKey: "created_at",
+      }
+    );
+    expect((await slice.edges()).map(({ node }) => node.name)).toEqual([
+      "4",
+      "d",
+      "1",
+      "b",
+    ]);
+  });
+
+  test("after when sortingKey is not id and sortingOrder is ASC", async () => {
+    const slice = new TypeORMRelayConnection(
+      qb,
+      {
+        after: "5",
+        first: 4,
+      },
+      {
+        sortingOrder: "ASC",
+        sortingKey: "created_at",
+      }
+    );
+    expect((await slice.edges()).map(({ node }) => node.name)).toEqual([
+      "2",
+      "f",
+      "7",
+      "e",
+    ]);
+  });
 });

--- a/src/TypeORMRelayConnection.ts
+++ b/src/TypeORMRelayConnection.ts
@@ -98,14 +98,14 @@ export default class TypeORMRelayConnection<T extends Entity> {
       if (this.args.after) {
         const subselect = `(SELECT ${sortingKey} FROM ${table} WHERE ${cursorKey} = :after)`;
         nodesScope.andWhere(
-          `(${alias}.${sortingKey} > ${subselect} OR (${alias}.${sortingKey} = ${subselect} AND ${alias}.${cursorKey} >= :after))`,
+          `(${alias}.${sortingKey} ${sortingOrder.toUpperCase() === 'ASC' ? '>' : '<'} ${subselect} OR (${alias}.${sortingKey} = ${subselect} AND ${alias}.${cursorKey} >= :after))`,
           { after: this.args.after }
         );
       }
       if (this.args.before) {
         const subselect = `(SELECT ${sortingKey} FROM ${table} WHERE ${cursorKey} = :before)`;
         nodesScope.andWhere(
-          `(${alias}.${sortingKey} < ${subselect} OR (${alias}.${sortingKey} = ${subselect} AND ${alias}.${cursorKey} <= :before))`,
+          `(${alias}.${sortingKey} ${sortingOrder.toUpperCase() === 'ASC' ? '<' : '>'} ${subselect} OR (${alias}.${sortingKey} = ${subselect} AND ${alias}.${cursorKey} <= :before))`,
           { before: this.args.before }
         );
       }


### PR DESCRIPTION
The previous logic with a hardcoded `>` and `<` only worked properly when the sorting order was ascending. This makes sure that when the query config is for descending order, we use the right comparison operator for `before` and `after` queries.